### PR TITLE
feat: add local sqlite backend

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,45 +1,73 @@
 import os
 import decimal
-from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
-import psycopg
-from psycopg.rows import dict_row
 
+USE_LOCAL_DB = os.environ.get("USE_LOCAL_DB")
 
-# --- Connection string ---
-raw_url = os.environ.get("SUPABASE_DB_URL")
-if not raw_url:
-    raise RuntimeError("SUPABASE_DB_URL is required. Set it via env vars.")
+if USE_LOCAL_DB:
+    import sqlite3
 
-# Normalize URL and enforce sslmode=require
-def _normalize_db_url(url: str) -> str:
-    parts = urlsplit(url.strip())
-    scheme = parts.scheme or "postgresql"
-    # Accept postgres / postgresql schemes; strip any SQLAlchemy driver suffix
-    if "+" in scheme:
-        scheme = scheme.split("+", 1)[0]
-    query = dict(parse_qsl(parts.query, keep_blank_values=True))
-    query["sslmode"] = query.get("sslmode") or "require"
-    new_query = urlencode(query)
-    return urlunsplit((scheme, parts.netloc, parts.path, new_query, parts.fragment))
+    DB_PATH = os.environ.get(
+        "LOCAL_DB_PATH", os.path.join(os.path.dirname(__file__), "local.db")
+    )
 
-DB_URL = _normalize_db_url(raw_url)
+    class SQLiteConn(sqlite3.Connection):
+        def execute(self, sql, params=()):  # type: ignore[override]
+            sql = sql.replace("%s", "?")
+            return super().execute(sql, params)
 
+    def get_conn():
+        """Return a sqlite3 connection with row access by name."""
+        conn = sqlite3.connect(DB_PATH, factory=SQLiteConn)
+        conn.row_factory = sqlite3.Row
+        return conn
 
-def get_conn():
-    """Return an autocommit psycopg3 connection using dict rows."""
-    return psycopg.connect(DB_URL, autocommit=True, row_factory=dict_row)
+    def run_schema():
+        """Execute schema.sql against the current database (idempotent)."""
+        from pathlib import Path
 
+        schema_path = Path(__file__).resolve().parent / "schema.sql"
+        sql = schema_path.read_text(encoding="utf-8")
 
-def run_schema():
-    """Execute schema.sql against the current database (idempotent)."""
-    from pathlib import Path
+        with get_conn() as conn:
+            conn.executescript(sql)
+else:
+    from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+    import psycopg
+    from psycopg.rows import dict_row
 
-    schema_path = Path(__file__).resolve().parent / "schema.sql"
-    sql = schema_path.read_text(encoding="utf-8")
+    # --- Connection string ---
+    raw_url = os.environ.get("SUPABASE_DB_URL")
+    if not raw_url:
+        raise RuntimeError("SUPABASE_DB_URL is required. Set it via env vars.")
 
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(sql)
+    # Normalize URL and enforce sslmode=require
+    def _normalize_db_url(url: str) -> str:
+        parts = urlsplit(url.strip())
+        scheme = parts.scheme or "postgresql"
+        # Accept postgres / postgresql schemes; strip any SQLAlchemy driver suffix
+        if "+" in scheme:
+            scheme = scheme.split("+", 1)[0]
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query["sslmode"] = query.get("sslmode") or "require"
+        new_query = urlencode(query)
+        return urlunsplit((scheme, parts.netloc, parts.path, new_query, parts.fragment))
+
+    DB_URL = _normalize_db_url(raw_url)
+
+    def get_conn():
+        """Return an autocommit psycopg3 connection using dict rows."""
+        return psycopg.connect(DB_URL, autocommit=True, row_factory=dict_row)
+
+    def run_schema():
+        """Execute schema.sql against the current database (idempotent)."""
+        from pathlib import Path
+
+        schema_path = Path(__file__).resolve().parent / "schema.sql"
+        sql = schema_path.read_text(encoding="utf-8")
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
 
 
 def to_float(val):

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from .db import get_conn, to_float, run_schema
+from .db import get_conn, to_float, run_schema, USE_LOCAL_DB
 
 
 app = FastAPI()
@@ -17,11 +17,12 @@ app = FastAPI()
 
 @app.on_event("startup")
 def _init_db_schema():
-    try:
-        run_schema()
-    except Exception as exc:
-        # Do not crash if schema already exists; just log
-        print(f"Schema init warning: {exc}", flush=True)
+    if USE_LOCAL_DB:
+        try:
+            run_schema()
+        except Exception as exc:
+            # Do not crash if schema already exists; just log
+            print(f"Schema init warning: {exc}", flush=True)
 
 
 # ---------- Pydantic models ----------

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,41 +1,37 @@
 -- Products
 CREATE TABLE IF NOT EXISTS products (
-barcode TEXT PRIMARY KEY,
-name TEXT,
-price NUMERIC(10,2) NOT NULL DEFAULT 0,
-stock INTEGER NOT NULL DEFAULT 0,
-updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  barcode TEXT PRIMARY KEY,
+  name TEXT,
+  price REAL NOT NULL DEFAULT 0,
+  stock INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-
 
 -- Sales header
 CREATE TABLE IF NOT EXISTS sales (
-id BIGSERIAL PRIMARY KEY,
-created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-total NUMERIC(10,2) NOT NULL DEFAULT 0
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  total REAL NOT NULL DEFAULT 0
 );
-
 
 -- Sales items
 CREATE TABLE IF NOT EXISTS sale_items (
-sale_id BIGINT NOT NULL REFERENCES sales(id) ON DELETE CASCADE,
-barcode TEXT NOT NULL REFERENCES products(barcode),
-qty INTEGER NOT NULL,
-price NUMERIC(10,2) NOT NULL,
-PRIMARY KEY (sale_id, barcode)
+  sale_id INTEGER NOT NULL REFERENCES sales(id) ON DELETE CASCADE,
+  barcode TEXT NOT NULL REFERENCES products(barcode),
+  qty INTEGER NOT NULL,
+  price REAL NOT NULL,
+  PRIMARY KEY (sale_id, barcode)
 );
-
 
 -- Inventory changes archive
 CREATE TABLE IF NOT EXISTS inventory_changes (
-id BIGSERIAL PRIMARY KEY,
-timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-barcode TEXT,
-details TEXT,
-delta_stock INTEGER
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  barcode TEXT,
+  details TEXT,
+  delta_stock INTEGER
 );
 
-
-CREATE INDEX IF NOT EXISTS idx_products_name ON products((lower(name)));
+CREATE INDEX IF NOT EXISTS idx_products_name ON products(lower(name));
 CREATE INDEX IF NOT EXISTS idx_inventory_changes_ts ON inventory_changes(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_sales_created_at ON sales(created_at DESC);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "backend:local": "USE_LOCAL_DB=1 uvicorn backend.main:app --reload"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add sqlite local database option controlled by USE_LOCAL_DB
- update schema for sqlite compatibility and skip schema init remotely
- add npm script to start backend using local db

## Testing
- `python -m py_compile backend/db.py backend/main.py`
- `USE_LOCAL_DB=1 python - <<'PY'
from backend.db import run_schema, get_conn
run_schema()
with get_conn() as conn:
    conn.execute('SELECT 1')
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a9a40ebfa483218c783ddad1b00fa6