### PR TITLE
feat: add offline storage and sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "grocery-scanner-preview",
       "version": "1.0.0",
       "dependencies": {
+        "localforage": "^1.10.0",
         "quagga": "^0.12.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1531,6 +1532,12 @@
         "npm": ">=1.3.7"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/iota-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
@@ -1630,6 +1637,24 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/lodash": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "quagga": "^0.12.1"
+    "quagga": "^0.12.1",
+    "localforage": "^1.10.0"
   },
   "devDependencies": {
     "vite": "^5.2.0",

--- a/src/api.js
+++ b/src/api.js
@@ -1,23 +1,94 @@
-export async function api(path, opts={}){
-const res = await fetch(path, {headers: {'Content-Type':'application/json'}, ...opts});
-if(!res.ok){
-let msg = await res.text();
-throw new Error(msg || res.statusText);
-}
-if (res.headers.get('content-type')?.includes('application/json')) return res.json();
-return res.text();
+import { productsStore, salesStore, queueStore } from './localdb';
+
+export async function api(path, opts = {}) {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...opts,
+  });
+  if (!res.ok) {
+    let msg = await res.text();
+    throw new Error(msg || res.statusText);
+  }
+  if (res.headers.get('content-type')?.includes('application/json')) return res.json();
+  return res.text();
 }
 
+async function queueRequest(path, opts) {
+  const key = Date.now().toString();
+  await queueStore.setItem(key, { path, opts });
+  const reg = await navigator.serviceWorker?.ready;
+  if (reg && 'sync' in reg) {
+    try {
+      await reg.sync.register('sync-queue');
+    } catch (e) {}
+  }
+}
 
 export const ProductsAPI = {
-list: (q='') => api(`/api/products${q?`?query=${encodeURIComponent(q)}`:''}`),
-get: (barcode) => api(`/api/products/${barcode}`),
-upsert: (p)=> api('/api/products/upsert', {method:'POST', body: JSON.stringify(p)}),
-changes: (limit=50)=> api(`/api/inventory_changes?limit=${limit}`)
-}
-
+  list: async (q = '') => {
+    if (navigator.onLine) {
+      const data = await api(`/api/products${q ? `?query=${encodeURIComponent(q)}` : ''}`);
+      data.forEach((p) => productsStore.setItem(p.barcode, p));
+      return data;
+    }
+    const all = [];
+    await productsStore.iterate((v) => all.push(v));
+    if (q) return all.filter((p) => p.name?.toLowerCase().includes(q.toLowerCase()));
+    return all;
+  },
+  get: async (barcode) => {
+    if (navigator.onLine) {
+      const p = await api(`/api/products/${barcode}`);
+      await productsStore.setItem(barcode, p);
+      return p;
+    }
+    return productsStore.getItem(barcode);
+  },
+  upsert: async (p) => {
+    if (navigator.onLine) {
+      const res = await api('/api/products/upsert', {
+        method: 'POST',
+        body: JSON.stringify(p),
+      });
+      await productsStore.setItem(p.barcode, res);
+      return res;
+    }
+    await productsStore.setItem(p.barcode, p);
+    await queueRequest('/api/products/upsert', {
+      method: 'POST',
+      body: JSON.stringify(p),
+    });
+    return p;
+  },
+  changes: (limit = 50) => api(`/api/inventory_changes?limit=${limit}`),
+};
 
 export const SalesAPI = {
-list: (limit=50)=> api(`/api/sales?limit=${limit}`),
-paid: (payload)=> api('/api/sale/paid', {method:'POST', body: JSON.stringify(payload)})
-}
+  list: async (limit = 50) => {
+    if (navigator.onLine) {
+      const data = await api(`/api/sales?limit=${limit}`);
+      data.forEach((s) => salesStore.setItem(s.id, s));
+      return data;
+    }
+    const all = [];
+    await salesStore.iterate((v) => all.push(v));
+    return all.slice(-limit);
+  },
+  paid: async (payload) => {
+    if (navigator.onLine) {
+      const res = await api('/api/sale/paid', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      await salesStore.setItem(res.id, res);
+      return res;
+    }
+    const offlineSale = { id: Date.now(), ...payload };
+    await salesStore.setItem(offlineSale.id, offlineSale);
+    await queueRequest('/api/sale/paid', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    return offlineSale;
+  },
+};

--- a/src/localdb.js
+++ b/src/localdb.js
@@ -1,0 +1,5 @@
+import localforage from 'localforage';
+
+export const productsStore = localforage.createInstance({ name: 'products' });
+export const salesStore = localforage.createInstance({ name: 'sales' });
+export const queueStore = localforage.createInstance({ name: 'queue' });

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,5 +2,10 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 
-
 createRoot(document.getElementById('root')).render(<App />)
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,45 @@
+importScripts('https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js');
+
+const CACHE = 'app-cache-v1';
+const ASSETS = ['/', '/index.html'];
+
+const queueStore = localforage.createInstance({ name: 'queue' });
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((res) => {
+      return (
+        res ||
+        fetch(event.request).then((fetchRes) => {
+          const copy = fetchRes.clone();
+          caches.open(CACHE).then((cache) => cache.put(event.request, copy));
+          return fetchRes;
+        })
+      );
+    })
+  );
+});
+
+async function processQueue() {
+  const keys = await queueStore.keys();
+  for (const key of keys) {
+    const { path, opts } = await queueStore.getItem(key);
+    try {
+      await fetch(path, { headers: { 'Content-Type': 'application/json' }, ...opts });
+      await queueStore.removeItem(key);
+    } catch (e) {
+      break;
+    }
+  }
+}
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-queue') {
+    event.waitUntil(processQueue());
+  }
+});


### PR DESCRIPTION
## Summary
- add localforage-backed stores for products, sales and queued requests
- update APIs to use local cache offline and queue writes for background sync
- introduce service worker caching static assets and processing queued requests

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9a6e168c88321b12713d419734c7c