### PR TITLE
Ensure products list returns items array

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -28,13 +28,15 @@ export const ProductsAPI = {
   list: async (q = '') => {
     if (navigator.onLine) {
       const data = await api(`/api/products${q ? `?query=${encodeURIComponent(q)}` : ''}`);
-      data.forEach((p) => productsStore.setItem(p.barcode, p));
-      return data;
+      const items = data.items || [];
+      items.forEach((p) => productsStore.setItem(p.barcode, p));
+      return { items };
     }
     const all = [];
     await productsStore.iterate((v) => all.push(v));
-    if (q) return all.filter((p) => p.name?.toLowerCase().includes(q.toLowerCase()));
-    return all;
+    let items = all;
+    if (q) items = items.filter((p) => p.name?.toLowerCase().includes(q.toLowerCase()));
+    return { items };
   },
   get: async (barcode) => {
     if (navigator.onLine) {


### PR DESCRIPTION
## Summary
- Fix ProductsAPI.list to cache and return products via the `items` array
- Maintain consistent response shape for offline product queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaf815d18c8321a8d5df1ff644b670