### PR TITLE
Ensure SalesAPI list returns items array

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -69,12 +69,12 @@ export const SalesAPI = {
   list: async (limit = 50) => {
     if (navigator.onLine) {
       const data = await api(`/api/sales?limit=${limit}`);
-      data.forEach((s) => salesStore.setItem(s.id, s));
-      return data;
+      data.items.forEach((s) => salesStore.setItem(s.id, s));
+      return { items: data.items };
     }
     const all = [];
     await salesStore.iterate((v) => all.push(v));
-    return all.slice(-limit);
+    return { items: all.slice(-limit) };
   },
   paid: async (payload) => {
     if (navigator.onLine) {


### PR DESCRIPTION
## Summary
- Iterate over `data.items` when caching sales
- Return `{ items: data.items }` and mirror structure offline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aafd52eb8883219536bde689f08173