### PR TITLE
Store local product after upsert

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -52,7 +52,7 @@ export const ProductsAPI = {
         method: 'POST',
         body: JSON.stringify(p),
       });
-      await productsStore.setItem(p.barcode, res);
+      await productsStore.setItem(p.barcode, p);
       return res;
     }
     await productsStore.setItem(p.barcode, p);


### PR DESCRIPTION
## Summary
- save original product data to local store after successful upsert and still return server response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aafdd08c3883219f4f25d7f9ad8b72