### PR TITLE
feat: add minimal service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp sw.js dist/",
     "preview": "vite preview --port 5173",
     "backend:local": "USE_LOCAL_DB=1 uvicorn backend.main:app --reload"
   },


### PR DESCRIPTION
## Summary
- implement minimal service worker that syncs queued requests
- ensure build copies service worker into deployment output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaff696c488321bc907131039c0566